### PR TITLE
Add Run Code shortcut

### DIFF
--- a/codemirror6/editor/extensions/shortcuts.js
+++ b/codemirror6/editor/extensions/shortcuts.js
@@ -1,12 +1,13 @@
 import {keymap} from "@codemirror/view";
 import {acceptCompletion} from "@codemirror/autocomplete";
 import {defaultKeymap, indentLess, indentMore} from "@codemirror/commands";
+import { Prec } from "@codemirror/state";
 
 import {deleteFile} from "../files/delete";
 import {downloadFile} from "../files/download.js";
 
-export const shortcuts = keymap.of([
-  ...defaultKeymap,
+
+export const shortcuts = Prec.highest(keymap.of([
   {
     key: "Tab",
     preventDefault: true,
@@ -46,5 +47,15 @@ export const shortcuts = keymap.of([
       i.focus();
       i.remove();
     }
-  }
-])
+  },
+  {
+    key: "Mod-Enter",
+    preventDefault: true,
+    run: () => {
+      const button = document.querySelector("#run-button");
+      button.click();
+      return true; // Stop the default keymap of creating a new line from running
+    }
+  },
+  ...defaultKeymap
+]))


### PR DESCRIPTION
This pull request adds a new shortcut to the code editor that allows users to run their code with a single key combination. 

I've set the shortcut to be Control/Command + Enter.

For this, I had to add`Prec.highest()`. The shortcut I used is by default used to make a new line underneath your current one. This function increases the precedence of the custom keymap and overrides the default one.

There is one issue with this, which is that when you use the shortcut, your cursor gets set to the top of the file. Unfortunately, I was unable to find the cause of this or fix it.